### PR TITLE
Add common layout + add support for Dark Theme

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -17,4 +17,11 @@
     --color-primary-900: #a5371b;
 }
 
+@font-face {
+    font-family: 'JetBrains Mono';
+    font-weight: 500;
+    font-style: normal;
+    src: url('https://fonts.googleapis.com/css2?family=JetBrains+Mono&display=swap');
+}
+
 @source "../node_modules/flowbite-svelte/dist";

--- a/src/app.html
+++ b/src/app.html
@@ -6,7 +6,7 @@
 	<meta content="width=device-width, initial-scale=1" name="viewport" />
 	%sveltekit.head%
 </head>
-<body data-sveltekit-preload-data="hover">
+<body class="bg-white dark:bg-gray-800" data-sveltekit-preload-data="hover">
 <div style="display: contents">%sveltekit.body%</div>
 </body>
 </html>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,5 +1,23 @@
 <script>
+	import { Navbar, NavBrand, NavLi, NavUl, NavHamburger, DarkMode } from 'flowbite-svelte';
+	import '/src/app.css';
+	import { page } from '$app/state';
 	let { children } = $props();
-	import "../app.css";
 </script>
+<Navbar class="m-auto lg:w-5xl">
+	<NavBrand href="/">
+		<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/1b/Svelte_Logo.svg/640px-Svelte_Logo.svg.png" class="me-3 h-6 sm:h-9" alt="Svelte framkework logo"/>
+		<span class="self-center whitespace-nowrap text-xl font-semibold dark:text-white">ITMO Frontend Courses</span>
+	</NavBrand>
+	<div class="flex md:order-2">
+		<DarkMode />
+		<NavHamburger />
+	</div>
+	<NavUl class="order-1" activeUrl={page.url.pathname}>
+		<NavLi href="/">Home</NavLi>
+		<NavLi href="/courses">Courses</NavLi>
+		<NavLi href="/resumes">Resumes</NavLi>
+	</NavUl>
+
+</Navbar>
 {@render children()}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { Button, ButtonGroup } from 'flowbite-svelte';
+	import '/src/app.css';
 </script>
 
 <svelte:head>

--- a/src/routes/courses/+page.svelte
+++ b/src/routes/courses/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+	import '/src/app.css';
+	import { Heading } from 'flowbite-svelte';
+</script>
+
+<Heading tag="h1">I am list of all courses</Heading>

--- a/src/routes/courses/[courseId]/+page.svelte
+++ b/src/routes/courses/[courseId]/+page.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 	import type { PageProps } from './$types';
+	import '/src/app.css';
+	import { Heading } from 'flowbite-svelte';
 
 	const { data }: PageProps = $props();
 </script>
 <svelte:head>
 	<title>Courses</title>
 </svelte:head>
-<h1>I am page of course with id = {data.courseId}</h1>
+<Heading tag="h1">I am page of course with id = {data.courseId}</Heading>

--- a/src/routes/lectures/[lectureId]/+page.svelte
+++ b/src/routes/lectures/[lectureId]/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import type { PageProps } from './$types';
+	import '/src/app.css';
+	import { Heading } from 'flowbite-svelte';
 
 	const { data }: PageProps = $props();
 </script>
@@ -8,6 +10,6 @@
 	<title>Lectures</title>
 </svelte:head>
 
-<h1>I am page of lecture with id = {data.lectureId}</h1>
+<Heading tag="h1">I am page of lecture with id = {data.lectureId}</Heading>
 
-<h1>Course id = {data.courseId}</h1>
+<Heading tag="h1">Course id = {data.lectureId}</Heading>

--- a/src/routes/resumes/+page.svelte
+++ b/src/routes/resumes/+page.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
 	import type { PageProps } from './$types';
+	import '/src/app.css';
+	import { Card, Heading, P } from 'flowbite-svelte';
 
 	const { data }: PageProps = $props();
 </script>
@@ -9,39 +11,27 @@
 </svelte:head>
 
 <main>
-	<header>
-		<h1>Welcome to ITMO Frontend Course</h1>
-		<p>This site is a Work-in-Progress. You can view participants' resumes below.</p>
+	<header class="flex flex-col items-center gap-4">
+		<Heading tag="h1">Welcome to ITMO Frontend Course</Heading>
+		<P class="text-lg text-gray-700 dark:text-gray-300">This site is a Work-in-Progress. You can view participants' resumes below.</P>
 	</header>
 
-	<section class="card-grid">
+	<section class="flex flex-row flex-wrap gap-4 justify-center">
 		{#each data.authors as author (author.documentId)}
-			<a class="card" href="/resumes/{author.documentId}">
+			<Card class="w-xs flex flex-col gap-4 items-center shadow-lg hover:shadow-xl hover:-translate-y-1 transition-all" href="/resumes/{author.documentId}">
 				<div class="avatar">
 					<span>{author.name[0]}</span>
 				</div>
-				<h2>{author.name}</h2>
-			</a>
+				<P>{author.name}</P>
+			</Card>
 		{/each}
 	</section>
 </main>
 
 <style>
-    @font-face {
-        font-family: 'JetBrains Mono';
-        font-weight: 500;
-        font-style: normal;
-        src: url('https://fonts.googleapis.com/css2?family=JetBrains+Mono&display=swap');
-    }
-
-    :global(body) {
-        margin: 0;
-        font-family: 'JetBrains Mono', monospace;
-        color: #363e45;
-        background-color: #f4f4f4;
-    }
 
     main {
+        font-family: 'JetBrains Mono', monospace;
         max-width: 1200px;
         margin: 0 auto;
         padding: 2rem;
@@ -51,48 +41,6 @@
         text-align: center;
         margin-bottom: 3rem;
         font-family: 'JetBrains Mono', monospace;
-    }
-
-    header h1 {
-        font-size: 2.8rem;
-        margin-bottom: 0.8rem;
-        color: #2c2c2c;
-    }
-
-    header p {
-        font-size: 1.1rem;
-        color: #666;
-    }
-
-    .card-grid {
-        display: grid;
-        grid-template-columns: repeat(3, 1fr);
-        gap: 2rem;
-    }
-
-    .card {
-        text-decoration: none;
-        color: inherit;
-        background-color: #ffffff;
-        border-radius: 16px;
-        padding: 2rem 1.5rem;
-        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.06);
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        transition: transform 0.2s ease,
-        box-shadow 0.2s ease;
-    }
-
-    .card:hover {
-        transform: translateY(-4px);
-        box-shadow: 0 6px 18px rgba(0, 0, 0, 0.1);
-    }
-
-    .card h2 {
-        margin-top: 1rem;
-        font-size: 1.3rem;
-        color: #333;
     }
 
     .avatar {
@@ -107,17 +55,5 @@
         align-items: center;
         justify-content: center;
         box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.05);
-    }
-
-    @media (max-width: 1024px) {
-        .card-grid {
-            grid-template-columns: repeat(2, 1fr);
-        }
-    }
-
-    @media (max-width: 768px) {
-        .card-grid {
-            grid-template-columns: 1fr;
-        }
     }
 </style>

--- a/src/routes/resumes/[resumeId]/+page.svelte
+++ b/src/routes/resumes/[resumeId]/+page.svelte
@@ -7,6 +7,7 @@
 	import SkillsSection from '$lib/sections/SkillsSection.svelte';
 	import ContactsSection from '$lib/sections/ContactsSection.svelte';
 	import Footer from '$lib/sections/Footer.svelte';
+	import '/src/app.css';
 
 	const { data }: PageProps = $props();
 </script>
@@ -15,7 +16,7 @@
 	<title>Resume</title>
 </svelte:head>
 
-<div class="Content">
+<div class="Content bg-primary-100">
 	<NavHeader />
 	<AboutMeSection name={data.author.name} />
 	<EducationSection educations={data.author.educations} />


### PR DESCRIPTION
I have added common layout for all pages with special Svelte feature - [layouts](https://svelte.dev/docs/kit/routing#layout)

Also, I have rewriten resume choosing page on Tailwind CSS.

Because of that, our site supports darkmode now. Only resume of concrete persons stays in light theme, because we are planning to rewrite it anyway, no reason to do useless work