### PR TITLE
Get rid of documentId

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
 				"prettier": "^3.4.2",
 				"prettier-plugin-svelte": "^3.3.3",
 				"svelte": "^5.0.0",
-				"svelte-check": "^4.0.0",
+				"svelte-check": "^4.1.6",
 				"typescript": "^5.0.0",
 				"typescript-eslint": "^8.20.0",
 				"vite": "^6.0.0"
@@ -4727,9 +4727,9 @@
 			}
 		},
 		"node_modules/svelte-check": {
-			"version": "4.1.5",
-			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.1.5.tgz",
-			"integrity": "sha512-Gb0T2IqBNe1tLB9EB1Qh+LOe+JB8wt2/rNBDGvkxQVvk8vNeAoG+vZgFB/3P5+zC7RWlyBlzm9dVjZFph/maIg==",
+			"version": "4.1.6",
+			"resolved": "https://registry.npmjs.org/svelte-check/-/svelte-check-4.1.6.tgz",
+			"integrity": "sha512-P7w/6tdSfk3zEVvfsgrp3h3DFC75jCdZjTQvgGJtjPORs1n7/v2VMPIoty3PWv7jnfEm3x0G/p9wH4pecTb0Wg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -12,11 +12,11 @@ export interface TimeRange {
 }
 
 export function assertValidIDObject({ id }: IDObject) {
-	assertIsInt(id, 'id');
+	assertNotEmpty(id, 'id');
 }
 
 export interface IDObject {
-	id: number;
+	id: string;
 }
 
 export function assertValidSkill(skill: Skill) {
@@ -76,14 +76,7 @@ export function assertValidVotedPerson(votedPerson: VotedPerson) {
 	assertIsInt(votedPerson.person_score, 'person_score');
 }
 
-/**
- * I don't know why, but Strapi identifies authors in repo not with `id`, but with `documentId` field.
- *
- * I can send request single author from strapi only if I know documentId.
- * So I decided to delete `id` field and store `documentId` instead
- */
-export interface Author {
-	documentId: string;
+export interface Author extends IDObject{
 	name: string;
 	educations: Education[];
 	skills: Skill[];
@@ -93,13 +86,11 @@ export interface Author {
 }
 
 export interface AuthorComment extends IDObject {
-	documentId: string;
 	comment_description: string;
 	author: Author;
 }
 
 export interface Presentation extends IDObject {
-	documentId: string;
 	presentation_name: string;
 	presentation_description: string;
 	presentation_url: string;

--- a/src/lib/strapiRepository.ts
+++ b/src/lib/strapiRepository.ts
@@ -42,7 +42,7 @@ function parseSkill(json: object): Skill {
 		'skill_percent',
 		'number'
 	);
-	const result = { id: json.id, name: json.skill_name, value: json.skill_percent };
+	const result = { id: json.id.toString(), name: json.skill_name, value: json.skill_percent };
 	assertValidSkill(result);
 	return result;
 }
@@ -76,7 +76,7 @@ function parseEducation(json: object): Education {
 		'string'
 	);
 	const result = {
-		id: json.id,
+		id: json.id.toString(),
 		title: json.education_name,
 		subtitle: json.education_level,
 		timeRange: parseTimeRange(json)
@@ -123,7 +123,7 @@ function parseAuthor(json: unknown): Author {
 	const email = { value: json.person_email, href: `mailto:${json.person_email}` };
 	assertValidContact(email);
 	const result = {
-		documentId: json.documentId,
+		id: json.documentId,
 		name: json.person_name,
 		educations: json.educations.map(parseEducation),
 		skills: json.skills.map(parseSkill),
@@ -157,7 +157,7 @@ async function parseComment(json: unknown): Promise<AuthorComment> {
 	);
 
 	const result = {
-		id: json.id,
+		id: json.id.toString(),
 		documentId: json.documentId,
 		comment_description: json.comment_description,
 		author: await getAuthorByDocumentId(json.person.documentId)
@@ -186,7 +186,7 @@ async function parseVotedPerson(json: unknown): Promise<VotedPerson> {
 	);
 
 	const result = {
-		id: json.id,
+		id: json.id.toString(),
 		person_score: json.person_score,
 		author: await getAuthorByDocumentId(json.person.documentId)
 	};
@@ -228,7 +228,7 @@ async function parsePresentation(json: unknown): Promise<Presentation> {
 	const voted_persons = await Promise.all(json.voted_persons.map(parseVotedPerson));
 
 	const result = {
-		id: json.id,
+		id: json.id.toString(),
 		presentation_name: json.presentation_name,
 		presentation_description: json.presentation_description,
 		presentation_url: json.presentation_url,
@@ -351,42 +351,28 @@ async function getAuthorJson(
 		person_address: address,
 		person_phone: phone,
 		person_email: email,
-		educations: [{}],
-		skills: [{}],
-		created_presentations: [{}],
-		comments: [{}]
-	};
-
-	data.educations = educations.map((education) => {
-		return {
+		educations: educations.map(education => ({
 			education_name: education.title,
 			educate_start: education.timeRange.start,
 			educate_end: education.timeRange.end,
 			educate_level: education.subtitle
-		};
-	});
-
-	data.skills = skills.map((skill) => {
-		return {
+		})),
+		skills: skills.map(skill => ({
 			skill_name: skill.name,
 			skill_percent: skill.value
-		};
-	});
-
-	data.comments = comments.map((comment) => {
-		return {
-			comment_description: comment.comment_description,
-			person: data
-		};
-	});
-
-	data.created_presentations = presentations.map((presentation) => {
-		return {
+		})),
+		created_presentations: presentations.map(presentation => ({
 			presentation_name: presentation.presentation_name,
 			presentation_description: presentation.presentation_description,
 			voted_persons: {}
-		};
-	});
+		})),
+		comments: [{}]
+	};
+
+	data.comments = comments.map(comment => ({
+		comment_description: comment.comment_description,
+		person: data
+	}));
 
 	return data;
 }

--- a/src/routes/resumes/+page.svelte
+++ b/src/routes/resumes/+page.svelte
@@ -17,8 +17,8 @@
 	</header>
 
 	<section class="flex flex-row flex-wrap gap-4 justify-center">
-		{#each data.authors as author (author.documentId)}
-			<Card class="w-xs flex flex-col gap-4 items-center shadow-lg hover:shadow-xl hover:-translate-y-1 transition-all" href="/resumes/{author.documentId}">
+		{#each data.authors as author (author.id)}
+			<Card href="/resumes/{author.id}" class="w-xs flex flex-col gap-4 items-center shadow-lg hover:shadow-xl hover:-translate-y-1 transition-all">
 				<div class="avatar">
 					<span>{author.name[0]}</span>
 				</div>
@@ -29,7 +29,6 @@
 </main>
 
 <style>
-
     main {
         font-family: 'JetBrains Mono', monospace;
         max-width: 1200px;

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -2,7 +2,7 @@ import adapter from '@sveltejs/adapter-netlify';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 const config = {
-	preprocess: vitePreprocess(),
+	preprocess: vitePreprocess({ script: true }),
 	kit: { adapter: adapter() }
 };
 


### PR DESCRIPTION
Previously, somewhere in code we had stored simultaneously `id` and `documentId`. This is useless, we need only one of them.